### PR TITLE
Feat/migrate media3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     // Vesper SDK
-    implementation("com.endeavorstreaming.vesper:vesper-sdk:1.2.0-media3.dev") {
+    implementation("com.endeavorstreaming.vesper:vesper-sdk:1.2.0") {
         exclude(group = "androidx.media3")
     }
     implementation(libs.androidx.core.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,7 +51,7 @@ android {
 
 dependencies {
     // Vesper SDK
-    implementation("com.endeavorstreaming.vesper:vesper-sdk:1.1.0") {
+    implementation("com.endeavorstreaming.vesper:vesper-sdk:1.2.0-media3.dev") {
         exclude(group = "androidx.media3")
     }
     implementation(libs.androidx.core.ktx)


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2630

Bump vesper-sdk-android to migrate media3 from 1.2.1 to 1.4.1